### PR TITLE
add translate button for user and bot sentences

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,49 @@
 
 This project uses the Whisper model by OpenAI, available on Hugging Face
 
-### This project uses the:
+## 🤖 Models and Licenses
 
-[Whisper model](https://huggingface.co/openai/whisper-small.en) under the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).
+This project uses several open-source AI models from Hugging Face.  
+Each model retains its original license as listed below:
 
-[Kokoro-82M model](https://huggingface.co/hexgrad/Kokoro-82M) under the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).
+### 🔊 Speech Recognition
+- [**Whisper Small (English)**](https://huggingface.co/openai/whisper-small.en)  
+  Licensed under the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).  
+  Developed by [**OpenAI**](https://openai.com/)
 
-[Qwen2.5-1.5B-Instruct model](https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct?inference_provider=hf-inference) under the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).
+### 🗣️ Text-to-Speech (TTS)
+- [**Kokoro-82M**](https://huggingface.co/hexgrad/Kokoro-82M)  
+  Licensed under the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).  
+  Developed by [**Hexgrad**](https://github.com/hexgrad)
+
+### 💬 Natural Language Processing (Chat & Grammar)
+- [**Qwen2.5-1.5B-Instruct**](https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct)  
+  Licensed under the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).  
+  Developed by [**Qwen Team**](https://qwen.ai/)
+
+### 🌐 Translation
+- [**Allegro/BiDi-eng-pol**](https://huggingface.co/allegro/BiDi-eng-pol)  
+  Licensed under the [Creative Commons Attribution 4.0 International License (CC BY 4.0)](https://choosealicense.com/licenses/cc-by-4.0/).  
+  Developed by [**Allegro ML Research**](https://ml.allegro.tech/)
+
+---
+
+## ⚖️ License Notice
+
+This project integrates open-source models and fully complies with their respective licenses.  
+All rights to the models belong to their original creators.  
+The source code of this application is distributed separately under the license defined in this repository.
 
 
-The code for this project is available under the MIT license
+## 🙏 Attributions
+
+This project would not be possible without the amazing work of the open-source community.  
+Special thanks to the teams and organizations that created and maintain the following models and tools:
+
+- **[OpenAI](https://openai.com/)** for [**Whisper Small (English)**](https://huggingface.co/openai/whisper-small.en) — Licensed under [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).  
+- **[Hexgrad](https://github.com/hexgrad)** for [**Kokoro-82M**](https://huggingface.co/hexgrad/Kokoro-82M) — Licensed under [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).  
+- **[Qwen Team](https://qwen.ai/)** for [**Qwen2.5-1.5B-Instruct**](https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct) — Licensed under [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).  
+- **[Allegro ML Research](https://ml.allegro.tech/)** for [**BiDi-eng-pol**](https://huggingface.co/allegro/BiDi-eng-pol) — Licensed under [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).  
+
+This application uses these models for educational and research purposes only, in full compliance with their respective licenses.  
+All rights, trademarks, and credits belong to their original creators.

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.routes.nlp import load_model_nlp, router as nlp_router
 from app.routes.tts import load_model_tts
 from app.routes.asr import load_model_asr, router as asr_router
+from app.routes.translation import load_model_translation, router as trans_router
 import os
 
 # Initialize application
@@ -21,6 +22,9 @@ app.add_middleware(
 # Load the pre-trained NLP 
 app.state.model_nlp, app.state.tokenizer_nlp = load_model_nlp()
 
+# Load the pre-trained Translation
+app.state.model_trans, app.state.tokenizer_trans = load_model_translation()
+
 # Load the pre-trained TTS 
 app.state.model_tts = load_model_tts()
 
@@ -29,6 +33,8 @@ app.state.processor_asr, app.state.model_asr = load_model_asr()
 
 # Include the NLP router
 app.include_router(nlp_router, prefix="/nlp", tags=["NLP"])
+# Include the translation router
+app.include_router(trans_router)
 # Include the ASR router
 app.include_router(asr_router)
 

--- a/app/routes/translation.py
+++ b/app/routes/translation.py
@@ -1,8 +1,12 @@
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 from fastapi import APIRouter, Request
+from pydantic import BaseModel
 
 model_name = "allegro/BiDi-eng-pol"
 router = APIRouter()
+
+class TextInput(BaseModel):
+    text: str 
 
 # Ładowanie modelu tłumaczenia
 def load_model_translation():
@@ -11,11 +15,11 @@ def load_model_translation():
     return model, tokenizer
 
 @router.post("/translate")
-async def translate_text(request: Request, sentence_eng: str):
+async def translate_text(request: Request, text: TextInput):
     model, tokenizer = request.app.state.model_trans, request.app.state.tokenizer_trans
 
     # Prefiks >>pol<< informuje model, że ma tłumaczyć na polski
-    text = ">>pol<< " + sentence_eng
+    text = ">>pol<< " + text.text
 
     # Tokenizacja i generowanie tłumaczenia
     inputs = tokenizer([text], return_tensors="pt", padding=True)

--- a/app/routes/translation.py
+++ b/app/routes/translation.py
@@ -1,0 +1,25 @@
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+from fastapi import APIRouter, Request
+
+model_name = "allegro/BiDi-eng-pol"
+router = APIRouter()
+
+# Ładowanie modelu tłumaczenia
+def load_model_translation():
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForSeq2SeqLM.from_pretrained(model_name)
+    return model, tokenizer
+
+@router.post("/translate")
+async def translate_text(request: Request, sentence_eng: str):
+    model, tokenizer = request.app.state.model_trans, request.app.state.tokenizer_trans
+
+    # Prefiks >>pol<< informuje model, że ma tłumaczyć na polski
+    text = ">>pol<< " + sentence_eng
+
+    # Tokenizacja i generowanie tłumaczenia
+    inputs = tokenizer([text], return_tensors="pt", padding=True)
+    translated = model.generate(**inputs)
+    decoded_translation = tokenizer.decode(translated[0], skip_special_tokens=True)
+
+    return {"translation": decoded_translation}

--- a/frontend/src/components/Chat/ChatBox.jsx
+++ b/frontend/src/components/Chat/ChatBox.jsx
@@ -92,6 +92,11 @@ function ChatBox() {
                         <div className="message-content">
                             <p>{msg.text}</p>
 
+                            {/* tłumaczenie nad przyciskami */}
+                            {translations[index] && visibleTranslations[index] && (
+                                <p className="translation">{translations[index]}</p>
+                            )}
+
                             <div className="message-buttons">
                                 {msg.audio && (
                                     <button
@@ -114,15 +119,12 @@ function ChatBox() {
                                 )}
 
                                 {translations[index] && visibleTranslations[index] && (
-                                    <>
-                                        <p className="translation">{translations[index]}</p>
-                                        <button
-                                            className="hide-btn"
-                                            onClick={() => toggleTranslation(index)}
-                                        >
-                                            Hide Translation
-                                        </button>
-                                    </>
+                                    <button
+                                        className="hide-btn"
+                                        onClick={() => toggleTranslation(index)}
+                                    >
+                                        Hide Translation
+                                    </button>
                                 )}
 
                                 {translations[index] && !visibleTranslations[index] && (

--- a/frontend/src/components/Chat/ChatBox.jsx
+++ b/frontend/src/components/Chat/ChatBox.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import MessageInput from './MessageInput';
 import { useChat } from '../../hooks/useChat';
 import { translateText } from '../../services/chatTranslation';
+import { Play, Pause } from 'lucide-react';
 import "./chat.css";
 
 function ChatBox() {
@@ -9,6 +10,8 @@ function ChatBox() {
     const messagesEndRef = useRef(null);
     const [translations, setTranslations] = useState({});
     const [visibleTranslations, setVisibleTranslations] = useState({});
+    const [playingIndex, setPlayingIndex] = useState(null);
+    const audioPlayerRef = useRef(new Audio());
 
     // Auto-scroll 
     useEffect(() => {
@@ -49,6 +52,30 @@ function ChatBox() {
         }));
     };
 
+    const handlePlayAudio = (index, audioSrc) => {
+        const player = audioPlayerRef.current;
+
+        // Jeśli aktualnie odtwarzamy to samo audio - zatrzymaj
+        if (playingIndex === index) {
+            player.pause();
+            setPlayingIndex(null);
+            return;
+        }
+
+        // Zatrzymaj poprzednie audio jeśli było odtwarzane
+        player.pause();
+
+        // Ustaw nowe źródło i odtwórz
+        player.src = audioSrc;
+        player.play();
+        setPlayingIndex(index);
+
+        // Resetuj stan po zakończeniu odtwarzania
+        player.onended = () => {
+            setPlayingIndex(null);
+        };
+    };
+
     return (
         <div className="chatbox">
             <div className="chat-header">
@@ -65,44 +92,48 @@ function ChatBox() {
                         <div className="message-content">
                             <p>{msg.text}</p>
 
-                            {/* Audio bot (speech synthesis) */}
-                            {msg.audio && (
-                                <audio src={msg.audio} controls className="bot-audio" />
-                            )}
-
-                            {/* Przycisk tłumaczenia — tylko jeśli brak tłumaczenia */}
-                            {!translations[index] && (
-                                <button
-                                    className="translate-btn"
-                                    onClick={() => handleTranslate(index, msg.text)}
-                                    disabled={loading}
-                                >
-                                    Translate
-                                </button>
-                            )}
-
-                            {/* Wyświetlane tłumaczenie */}
-                            {translations[index] && visibleTranslations[index] && (
-                                <>
-                                    <p className="translation">{translations[index]}</p>
+                            <div className="message-buttons">
+                                {msg.audio && (
                                     <button
-                                        className="hide-btn"
+                                        onClick={() => handlePlayAudio(index, msg.audio)}
+                                        title={playingIndex === index ? "Wstrzymaj" : "Odtwórz nagranie"}
+                                        className={`mess ${playingIndex === index ? "pause" : "play"}`}
+                                    >
+                                        {playingIndex === index ? <Pause size={20} /> : <Play size={20} />}
+                                    </button>
+                                )}
+
+                                {!translations[index] && (
+                                    <button
+                                        className="show-btn"
+                                        onClick={() => handleTranslate(index, msg.text)}
+                                        disabled={loading}
+                                    >
+                                        Translate
+                                    </button>
+                                )}
+
+                                {translations[index] && visibleTranslations[index] && (
+                                    <>
+                                        <p className="translation">{translations[index]}</p>
+                                        <button
+                                            className="hide-btn"
+                                            onClick={() => toggleTranslation(index)}
+                                        >
+                                            Hide Translation
+                                        </button>
+                                    </>
+                                )}
+
+                                {translations[index] && !visibleTranslations[index] && (
+                                    <button
+                                        className="show-btn"
                                         onClick={() => toggleTranslation(index)}
                                     >
-                                        Hide Translation
+                                        Translate
                                     </button>
-                                </>
-                            )}
-
-                            {/* Pokaż tłumaczenie jeśli jest ukryte */}
-                            {translations[index] && !visibleTranslations[index] && (
-                                <button
-                                    className="show-btn"
-                                    onClick={() => toggleTranslation(index)}
-                                >
-                                    Translate
-                                </button>
-                            )}
+                                )}
+                            </div>
                         </div>
 
                         <span className="message-time">

--- a/frontend/src/components/Chat/ChatBox.jsx
+++ b/frontend/src/components/Chat/ChatBox.jsx
@@ -1,16 +1,53 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import MessageInput from './MessageInput';
 import { useChat } from '../../hooks/useChat';
+import { translateText } from '../../services/chatTranslation';
 import "./chat.css";
 
 function ChatBox() {
     const { messages, sendMessage, sendAudioMessage, loading } = useChat();
     const messagesEndRef = useRef(null);
+    const [translations, setTranslations] = useState({});
+    const [visibleTranslations, setVisibleTranslations] = useState({});
 
     // Auto-scroll 
     useEffect(() => {
         messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
     }, [messages]);
+
+    const handleTranslate = async (index, text) => {
+        setTranslations(prev => ({
+            ...prev,
+            [index]: "Translating..."
+        }));
+
+        try {
+            const res = await translateText(text);
+            setTranslations(prev => ({
+                ...prev,
+                [index]: res.translation || res.translated_text || "Translation unavailable."
+            }));
+
+            // pokaż tłumaczenie po zakończeniu
+            setVisibleTranslations(prev => ({
+                ...prev,
+                [index]: true
+            }));
+        } catch (err) {
+            console.error("Translation error:", err);
+            setTranslations(prev => ({
+                ...prev,
+                [index]: "Translation failed."
+            }));
+        }
+    };
+
+    const toggleTranslation = (index) => {
+        setVisibleTranslations(prev => ({
+            ...prev,
+            [index]: !prev[index]
+        }));
+    };
 
     return (
         <div className="chatbox">
@@ -33,7 +70,41 @@ function ChatBox() {
                                 <audio src={msg.audio} controls className="bot-audio" />
                             )}
 
+                            {/* Przycisk tłumaczenia — tylko jeśli brak tłumaczenia */}
+                            {!translations[index] && (
+                                <button
+                                    className="translate-btn"
+                                    onClick={() => handleTranslate(index, msg.text)}
+                                    disabled={loading}
+                                >
+                                    Translate
+                                </button>
+                            )}
+
+                            {/* Wyświetlane tłumaczenie */}
+                            {translations[index] && visibleTranslations[index] && (
+                                <>
+                                    <p className="translation">{translations[index]}</p>
+                                    <button
+                                        className="hide-btn"
+                                        onClick={() => toggleTranslation(index)}
+                                    >
+                                        Hide Translation
+                                    </button>
+                                </>
+                            )}
+
+                            {/* Pokaż tłumaczenie jeśli jest ukryte */}
+                            {translations[index] && !visibleTranslations[index] && (
+                                <button
+                                    className="show-btn"
+                                    onClick={() => toggleTranslation(index)}
+                                >
+                                    Translate
+                                </button>
+                            )}
                         </div>
+
                         <span className="message-time">
                             {new Date().toLocaleTimeString('pl-PL', {
                                 hour: '2-digit',

--- a/frontend/src/components/Chat/chat.css
+++ b/frontend/src/components/Chat/chat.css
@@ -29,6 +29,12 @@
     font-size: clamp(1.3rem, 4vw, 2rem);
 }
 
+.chat-header p {
+    margin: 5px 0 0 0;
+    font-size: clamp(0.85rem, 2vw, 1rem);
+    color: #666;
+}
+
 .messages {
     flex: 1;
     padding: 10px;
@@ -67,6 +73,38 @@
     }
 }
 
+/* Message content container */
+.message-content {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.message-content p {
+    margin: 0;
+    line-height: 1.5;
+}
+
+.message-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 6px;
+    width: 100%;
+}
+
+/* Message time */
+.message-time {
+    display: block;
+    font-size: 0.75rem;
+    color: rgba(0, 0, 0, 0.5);
+    margin-top: 6px;
+    text-align: right;
+}
+
 /* Message bubbles */
 .user-msg {
     background: linear-gradient(135deg, #9069fd 0%, #c2c2c2 100%);
@@ -80,6 +118,107 @@
     color: #000000;
     margin-left: auto;
     text-align: left;
+}
+
+.error-msg {
+    background: linear-gradient(135deg, #ff6b6b 0%, #ee5a6f 100%);
+    color: white;
+}
+
+/* Bot audio player */
+.bot-audio {
+    width: 100%;
+    max-width: 300px;
+    height: 32px;
+    border-radius: 16px;
+    margin-top: 8px;
+}
+
+/* Translation text */
+.translation {
+    padding: 10px;
+    background: rgba(255, 255, 255, 0.3);
+    border-radius: 12px;
+    font-style: italic;
+    color: #333;
+    margin-top: 8px;
+    border-left: 3px solid #667eea;
+}
+
+/* Translation buttons */
+.hide-btn,
+.show-btn {
+    padding: 8px 16px;
+    border: none;
+    border-radius: 18px;
+    font-size: 0.65rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    margin-top: 8px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    font-family: "Inter", sans-serif;
+}
+
+.show-btn {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+}
+
+.show-btn:hover:not(:disabled) {
+    background: linear-gradient(135deg, #5568d3 0%, #63408a 100%);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 10px rgba(102, 126, 234, 0.3);
+}
+
+.hide-btn {
+    background: linear-gradient(135deg, #e0e0e0 0%, #bdbdbd 100%);
+    color: #333;
+}
+
+.hide-btn:hover:not(:disabled) {
+    background: linear-gradient(135deg, #d0d0d0 0%, #a0a0a0 100%);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+}
+
+.hide-btn:active:not(:disabled),
+.show-btn:active:not(:disabled) {
+    transform: translateY(0);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+}
+
+
+.mess {
+    border: none;
+    border-radius: 50%;
+    width: 40px;
+    height: 35px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    color: white;
+    flex-shrink: 0;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    margin-top: 5px;
+}
+
+.mess.pause {
+    background: linear-gradient(135deg, #f1276a 0%, #f70e0e 100%);
+}
+
+.mess.pause:hover:not(:disabled) {
+    background: linear-gradient(135deg, #f1276a 0%, #f70e0e 100%);
+}
+
+.mess.play {
+    background: linear-gradient(135deg, #51cf66 0%, #02a152 100%);
+}
+
+.mess.play:hover:not(:disabled) {
+    background: linear-gradient(135deg, #40c057 0%, #018a44 100%);
 }
 
 /* ============================================
@@ -285,11 +424,17 @@
         border-radius: 15px;
     }
 
-    .user,
-    .bot {
+    .message {
         max-width: 85%;
         padding: 12px 16px;
         font-size: 0.95rem;
+    }
+
+    .translate-btn,
+    .hide-btn,
+    .show-btn {
+        font-size: 0.8rem;
+        padding: 6px 14px;
     }
 
     .input-row {
@@ -323,16 +468,17 @@
         margin-bottom: 8px;
     }
 
-    .user,
-    .bot {
+    .message {
         max-width: 90%;
         padding: 10px 14px;
         font-size: 0.9rem;
     }
 
-    .user h3,
-    .bot h3 {
+    .translate-btn,
+    .hide-btn,
+    .show-btn {
         font-size: 0.75rem;
+        padding: 6px 12px;
     }
 
     .input-row {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -55,7 +55,6 @@ h1 {
 button {
   border-radius: 8px;
   border: 1px solid transparent;
-  padding: 0.6em 1.2em;
   font-weight: 500;
   font-family: inherit;
   background-color: #1a1a1a;

--- a/frontend/src/services/chatTranslation.js
+++ b/frontend/src/services/chatTranslation.js
@@ -1,0 +1,9 @@
+import axios from "axios";
+
+const API_BASE = "http://127.0.0.1:8000";
+
+// Sending text for translation
+export const translateText = async (text) => {
+    const response = await axios.post(`${API_BASE}/translate`, { text });
+    return response.data;
+};


### PR DESCRIPTION
This merge adds a translation feature for both user and bot messages, using the Allegro/BiDi-eng-pol model.

- Added "Translate" button next to each message
- Integrated backend translation handling
- Displayed translations directly below the original message
- Improved chat layout and button alignment
- Fixed layout issue: buttons now move below the translation text
- Updated README with model license info
